### PR TITLE
Catches blank or invalid clustering label.

### DIFF
--- a/cli/sccaf
+++ b/cli/sccaf
@@ -3,7 +3,7 @@
 import pandas as pd
 import matplotlib
 import matplotlib.pyplot as plt
-import scanpy.api as sc
+import scanpy as sc
 import SCCAF as sf
 import logging
 import argparse
@@ -11,6 +11,15 @@ from re import sub, match
 from sys import exit
 
 matplotlib.use('Agg')
+
+
+def non_empty_string(x):
+    if x is not None and len(x) > 0:
+        return x
+    else:
+        msg = "Value provided cannot be empty"
+        raise argparse.ArgumentTypeError(msg)
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--input-file",
@@ -26,7 +35,8 @@ parser.add_argument("--skip-assessment", action="store_true",
                     help="If --optimise given, then this allows to optionally skip the original "
                          "assessment of the clustering")
 parser.add_argument("-s", "--slot-for-existing-clustering",
-                    help="Use clustering pre-computed in the input object, available in this slot of the object.")
+                    help="Use clustering pre-computed in the input object, available in this slot of the object.",
+                    type=non_empty_string)
 parser.add_argument("-r", "--resolution", default=1.5, type=float,
                     help="Resolution for running clustering when no internal or external clustering is given.")
 parser.add_argument("-a", "--min-accuracy", type=float,
@@ -60,6 +70,11 @@ if args.external_clustering_tsv:
     cluster.columns = ['CLUSTER']
     y = (pd.merge(ad.obs, cluster, how='left', left_index=True, right_index=True))['CLUSTER']
 else:
+    if args.slot_for_existing_clustering not in ad.obs:
+        logging.error("Provided slot name '{}' is not in the provided AnnData object, "
+                      "make sure that you provide a valid clustering label inside the "
+                      "AnnData object provided.".format(args.slot_for_existing_clustering))
+        exit(1)
     y = ad.obs[args.slot_for_existing_clustering]
 
 raw = getattr(ad, 'raw')

--- a/cli/sccaf-assess
+++ b/cli/sccaf-assess
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import matplotlib
-import scanpy.api as sc
+import scanpy as sc
 import SCCAF as sf
 import logging
 import argparse
@@ -44,6 +44,11 @@ if args.external_clustering_tsv:
     y = (pd.merge(ad.obs, cluster, how='left', left_index=True, right_index=True))['CLUSTER']
     column_name = "external_clustering"
 else:
+    if args.slot_for_existing_clustering not in ad.obs:
+        logging.error("Provided slot name '{}' is not in the provided AnnData object, "
+                      "make sure that you provide a valid clustering label inside the "
+                      "AnnData object provided.".format(args.slot_for_existing_clustering))
+        exit(1)
     y = ad.obs[args.slot_for_existing_clustering]
     column_name = args.slot_for_existing_clustering
 accs_out_fn = "{}.csv".format(column_name)


### PR DESCRIPTION
Addresses #13 and also uses import scanpy in preparation of deprecation of scanpy.pi usage.